### PR TITLE
[Fix] minor fix of rope dims in non flash attention branch

### DIFF
--- a/utonia/model.py
+++ b/utonia/model.py
@@ -292,12 +292,16 @@ class SerializedAttention(PointModule):
         qkv = self.qkv(point.feat)[order]
 
         rope_coord = point.coord[order].clone()
+
+        qkv = qkv.reshape(-1, 3, H, C // H)
+        q, k, v = qkv.unbind(dim=1)
+        q, k = self.rope(q, k, rope_coord)
+
         if not self.enable_flash:
-            # encode and reshape qkv: (N', K, 3, H, C') => (3, N', H, K, C')
-            q, k, v = (
-                qkv.reshape(-1, K, 3, H, C // H).permute(2, 0, 3, 1, 4).unbind(dim=0)
-            )
-            q, k = self.rope(q, k, rope_coord)
+            q = q.reshape(-1, K, H, C // H).permute(0, 2, 1, 3)
+            k = k.reshape(-1, K, H, C // H).permute(0, 2, 1, 3)
+            v = v.reshape(-1, K, H, C // H).permute(0, 2, 1, 3)
+
             # attn
             if self.upcast_attention:
                 q = q.float()
@@ -311,9 +315,6 @@ class SerializedAttention(PointModule):
             attn = self.attn_drop(attn).to(qkv.dtype)
             feat = (attn @ v).transpose(1, 2).reshape(-1, C)
         else:
-            qkv = qkv.reshape(-1, 3, H, C // H)
-            q, k, v = qkv.unbind(dim=1)
-            q, k = self.rope(q, k, rope_coord)
             qkv_roped = torch.stack([q, k, v], dim=1)
             feat = flash_attn.flash_attn_varlen_qkvpacked_func(
                 qkv_roped.to(torch.bfloat16),


### PR DESCRIPTION
Hi, thank you for your amazing research !

I encountered the following error in `Point3DRoPE` when using the repo without flash attention : 

```bash
File"/workspace/Utonia/utonia/model.py", line 300, in forward q, k= self.rope(q, k, rope_coord)
File "/workspace/conda/envs/utonia_env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1739, in _wrapped_call_impl return self. call impl(*aras.
**kwaras)
File /workspace/conda/envs/utonia_env/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl return forward call (args,
**kwargs)
File"/workspace/Utonia/utonia/model.py", line 98, in forward
a part = sl coss (self rotate half(asil) * sinslil)
RuntimeError: The size of tensor a (3) must match the size of tensor b (188416) at non-singleton dimension 1
```

This is due to the current reshape before RoPE having q/k/v dimension of `N',H,K,C'` instead of `N'*K,H,C'` 

The output looks as expected : 

<img width="734" height="687" alt="Screenshot 2026-03-05 at 20 13 14" src="https://github.com/user-attachments/assets/5afb6337-7be7-42e1-995b-f8d9fc575f9d" />

<img width="946" height="777" alt="Screenshot 2026-03-05 at 20 17 51" src="https://github.com/user-attachments/assets/3343efb7-dd93-4606-86da-a5eee192828d" />
